### PR TITLE
Fixed the 128 res being invalid issue

### DIFF
--- a/Core/Src/Commands/SetScale.c
+++ b/Core/Src/Commands/SetScale.c
@@ -11,7 +11,7 @@
 
 bool check_res (uint16_t num) {
 	const uint16_t items[] = {1, 8, 16, 32, 64, 128 };
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < 6; i++)
     {
     	if (num == items[i]) return true;
     }


### PR DESCRIPTION
Discovered in CommandGen that due to missetting the iteratior limit, the program thought resolution 128 is invalid.
Fixed.