### PR TITLE
Cursors

### DIFF
--- a/Core/Inc/Flash.h
+++ b/Core/Inc/Flash.h
@@ -26,13 +26,14 @@
 #define ADDR_FLASH_PAGE_31    ((uint32_t)0x0800F800) /* Base address of Page 31, 2 Kbytes */
 
 #define FLASH_USER_START_ADDR   ADDR_FLASH_PAGE_20   /* Start @ of user Flash area */
-#define FLASH_USER_END_ADDR     ADDR_FLASH_PAGE_24   /* End @ of user Flash area */
+#define FLASH_USER_END_ADDR     ADDR_FLASH_PAGE_25   /* End @ of user Flash area */
 
 #define SETTINGS_ADDR 			ADDR_FLASH_PAGE_20
 #define I2C_QUEUE_PAGE_1_ADDR	ADDR_FLASH_PAGE_21
 #define I2C_QUEUE_PAGE_2_ADDR	ADDR_FLASH_PAGE_22 // separated an marked for clearance, won't be mentioned in code
 #define REQ_QUEUE_ADDR			ADDR_FLASH_PAGE_23
 #define SCHEDULER_ADDR			ADDR_FLASH_PAGE_24
+#define QUEUE_MANAGER_ADDR		ADDR_FLASH_PAGE_25
 
 
 #include <stdint.h>

--- a/Core/Inc/Queue.h
+++ b/Core/Inc/Queue.h
@@ -11,22 +11,22 @@
 #define QUEUE_SIZE 256
 #include <stdint.h>
 #include <stdbool.h>
+#include "QueueID.h"
+#include "QueueManager.h"
 
 typedef struct {
-    void* 		data;         	// pointer to the data array
-    uint16_t 	head;       	// starting index of the queue (0 - QUEUE_SIZE-1)
-    uint16_t 	tail;       	// ending index of the queue (0 - QUEUE_SIZE-1)
-    uint16_t	size;			// to seperate the number of new items from items that we can read (for example flash save)
-    uint16_t	max_size;
-    uint16_t 	item_size; 		// size of a signle item in queue (in bytes)
-    uint32_t*	flash_page;
-    uint8_t 	nf_pages;		// number of flash pages
+	QueueID			ID;
+    void* 			data;         	// pointer to the data array
+    QueueCursor*	cursor;
+    uint16_t		max_size;
+    uint16_t 		item_size; 		// size of a signle item in queue (in bytes)
+    uint32_t*		flash_page;
+    uint8_t 		nf_pages;		// number of flash pages
 } Queue;
 
 void queue_init(Queue* queue);
 void queue_push(Queue* queue, void* item);
 bool queue_get(Queue* queue, void** data);
-void queue_clear(Queue* queue);
 bool queue_delete(Queue* queue, bool (*condition)(void* item));
 void queue_save(Queue* queue);
 

--- a/Core/Inc/QueueID.h
+++ b/Core/Inc/QueueID.h
@@ -1,0 +1,16 @@
+/*
+ * QueueID.h
+ *
+ *  Created on: May 14, 2025
+ *      Author: hpraszpi
+ */
+
+#ifndef INC_QUEUEID_H_
+#define INC_QUEUEID_H_
+
+typedef enum {
+	I2C_QUEUE 		= 0x0,
+	REQUEST_QUEUE 	= 0x1
+} QueueID;
+
+#endif /* INC_QUEUEID_H_ */

--- a/Core/Inc/QueueManager.h
+++ b/Core/Inc/QueueManager.h
@@ -1,0 +1,26 @@
+/*
+ * QueueManager.h
+ *
+ *  Created on: May 14, 2025
+ *      Author: hpraszpi
+ */
+
+#ifndef INC_QUEUEMANAGER_H_
+#define INC_QUEUEMANAGER_H_
+
+#include <stdint.h>
+#include "QueueID.h"
+
+typedef struct {
+    uint16_t 	head;       	// starting index of the queue (0 - QUEUE_SIZE-1)
+    uint16_t 	tail;       	// ending index of the queue (0 - QUEUE_SIZE-1)
+    uint16_t	size;			// to seperate the number of new items from items that we can read (for example flash save)
+} QueueCursor;
+
+
+void queue_manager_init();
+QueueCursor* queue_manager_get_cursor(QueueID queue_id);
+void queue_manager_step_head(QueueID queue_id, uint16_t max_size);
+void queue_manager_step_tail(QueueID queue_id, uint16_t max_size);
+void queue_manager_save();
+#endif /* INC_QUEUEMANAGER_H_ */

--- a/Core/Inc/RequestQueue.h
+++ b/Core/Inc/RequestQueue.h
@@ -13,7 +13,5 @@
 void request_queue_init();
 void request_queue_put(Request request);
 Request request_queue_get(void);
-void request_queue_delete(uint8_t id);
-void request_queue_clear(void);
 
 #endif // INC_REQUESTQUEUE_H

--- a/Core/Inc/Scheduler.h
+++ b/Core/Inc/Scheduler.h
@@ -31,7 +31,5 @@ void scheduler_finish_measurement();
 void scheduler_request_measurement(uint8_t id, uint32_t start_time, uint8_t config);
 void scheduler_request_selftest(uint8_t id, uint32_t start_time, uint8_t priority);
 uint8_t scheduler_get_request_id(uint8_t idx);
-void scheduler_delete_request(uint8_t id);
-void scheduler_delete_all_requests();
 
 #endif /* INC_SCHEDULER_H_ */

--- a/Core/Src/Queue.c
+++ b/Core/Src/Queue.c
@@ -1,64 +1,75 @@
+/**
+ *             Queue.c/.h                                QueueManager.c/.h
+ *	+-------------------------+         +----------------------------+
+ *  |       QueueID (enum)    |         |    QueueCursor (struct)    |
+ *	|-------------------------|         |----------------------------|
+ *	| Values must be hardcoded|         | uint16_t head              |
+ *	|-------------------------|			| uint16_t tail              |
+ *	| I2C_QUEUE     = 0x0     |         | uint16_t size              |
+ *	| REQUEST_QUEUE = 0x1     |         +----+--------+--------------+
+ * 	+-----------+-------------+         	 |		  ^
+ *  	        |                            |        |
+ *      	    | identification              |        | (volatile QueueCursor[] cursors)
+ *          	| for cursor ops             |        |
+ *          	v                            |        |
+ *	+-------------------------+   read-only  |        |
+ *	|       Queue (struct)    |<-------------+		  |
+ *	|-------------------------| link (QueueCursor*    |
+ *	| Runtime-specific queue   |			Queue.cursor) |
+ *	| data (RAM address or    |                       |
+ *	| hardcoded information   |						  |
+ *	| won’t be saved (except  |						  |
+ *	| the CONTENT of data,    |						  |
+ *	| which is handled        |						  |
+ *	| separately))            |						  |
+ *	|-------------------------|  provides         +---+------------------------+
+ *	| void*        data       |<------------------| 	   QueueManager		   |
+ *	| uint16_t     size       |  cursor access    |		   (subsystem)		   |
+ *	| uint32_t     flash_page  |         		  |----------------------------|
+ *	| uint8_t      n_pages    |------------------>| Manages cursors            |
+ *	+-------------------------+	 asks for cursor  +----------------------------+
+ *								 updates
+ *
+ */
+
 #include "Queue.h"
 #include "Flash.h"
 #include <string.h>
 
+/**
+ * @note SHOULD BE ONLY CALLED by implementations (i2c and requests queues) AT SYSTEM INIT
+ * 		 AFTER QUEUE_MANAGER's initialization.
+ */
 void queue_init(Queue* queue) {
 	uint16_t load_length = (queue->max_size * queue->item_size);
     queue->data = malloc(load_length);
-    memset(queue->data, 0, load_length);
 
     // 1 flash read operation is 4 bytes (see flash_load docs).
     flash_load(queue->flash_page, load_length / 4, queue->data);
-    while(1) {
-    	bool is_valid = false;
-    	for(uint16_t i = 0; i < queue->item_size; i++) {
-    		if(*((uint16_t *)queue->data+(queue->tail*queue->item_size / 2)+i) != 0xFFFF) {
-    			is_valid = true;
-    			break;
-    		}
-    	}
-    	if(!is_valid) break;
-    	// additional safety in order to prevent overloading the queue
-    	if(queue->tail < queue->max_size) queue->tail++;
-    	else break;
-    }
-    queue->size = queue->tail;
-
+    queue->cursor = queue_manager_get_cursor(queue->ID);
 }
 
 void queue_push(Queue* queue, void* item) {
-
-	if(queue->tail > queue->max_size -1){queue->tail = 0;}; //if the queue reaches its max, it overflows from the beginning
-
-	memcpy(queue->data + queue->tail * queue->item_size, item, queue->item_size);
-	queue->tail = (queue->tail + 1 + QUEUE_SIZE) % QUEUE_SIZE;
- 	if(queue->size > queue->max_size-1){queue->size = 128;} else {queue->size++;}; //additional safety
+	memcpy(queue->data + queue->cursor->tail * queue->item_size, item, queue->item_size);
+	queue_manager_step_tail(queue->ID, queue->max_size);
 }
 
 bool queue_get(Queue* queue, void** data) {
-    if (queue->size == 0){
+    if (queue->cursor->size == 0){
  		data = 0;
  		return false;
  	}
-    if(queue->head > queue->max_size -1){queue->head = 0;}; //if the read position reaches its max, it starts from the beginning
- 	void* item = queue->data+queue->head*queue->item_size;
- 	queue->head = (queue->head + 1 + QUEUE_SIZE) % QUEUE_SIZE;;
- 	if(queue->size > 0) {queue->size--;};	//additional safety
 
- 	*data = item;
+ 	*data = queue->data+queue->cursor->head*queue->item_size;
+    queue_manager_step_head(queue->ID, queue->max_size);
+
  	return true;
-}
-
-void queue_clear(Queue* queue) {
-    queue->head = 0;
- 	queue->tail = 0;
- 	queue->size = 0;
 }
 
 void queue_save(Queue* queue) {
 	flash_save(queue->flash_page,
 		queue->nf_pages,
-		queue->size*queue->item_size/2, // 1 flash write operation is 2 bytes
-		(uint16_t*)queue->data+(queue->head*queue->item_size/2)
+		queue->item_size*queue->max_size/2, // 1 flash write operation is 2 bytes
+		(uint16_t*)queue->data
 	);
 }

--- a/Core/Src/QueueManager.c
+++ b/Core/Src/QueueManager.c
@@ -1,0 +1,90 @@
+/*
+ * QueueManager.c
+ *
+ *  Created on: May 14, 2025
+ *      Author: hpraszpi
+ */
+
+#include "QueueManager.h"
+#include "Flash.h"
+
+// a random, but consistent value that validates the flash page at load
+#define CURSOR_FLASH_VALIDITY 0x435FB103
+
+#define CURSORS_LENGTH 2
+volatile QueueCursor cursors[CURSORS_LENGTH];
+
+/*
+ * @note SHOULD BE CALLED AT SYSTEM INIT BEFORE ANY OTHER QUEUE's.
+ */
+void queue_manager_init() {
+	// the load_length is calculated in flash read ops (1 read op = 4 byte) - see flash_load docs.
+	// +1 is added to the length to load the check uint32_t from flash (that validates our cursors).
+	uint16_t load_length = (CURSORS_LENGTH * sizeof(QueueCursor)) / 4 + 1;
+	uint32_t load_data[load_length];
+	flash_load(QUEUE_MANAGER_ADDR, load_length, load_data);
+
+	if(load_data[0] != CURSOR_FLASH_VALIDITY) {
+		// flash invalid
+		memset(cursors, 0, CURSORS_LENGTH * sizeof(QueueCursor)); // additional safety. makes sure the cursors empty
+		return;
+	}
+	memcpy(cursors, load_data+1, CURSORS_LENGTH * sizeof(QueueCursor));
+}
+
+/*
+ * @note The pointer that this method returns MUST BE HANDLED as a READ-ONLY reference!
+ * @returns A READ-ONLY reference of the requested queue cursor.
+ */
+QueueCursor* queue_manager_get_cursor(QueueID queue_id){
+	return cursors+queue_id;
+}
+
+/*
+ * @brief steps head forward on requested cursor (used when querying the queue)
+ * @param	queue_id	defines which queue cursor's modification is requested
+ * @param	max_size	Head limit. If head reaches this boundary, we set it back to zero.
+ */
+void queue_manager_step_head(QueueID queue_id, uint16_t max_size){
+	// inside queue manager modifications on pointers returned by queue_manager_get_cursor are allowed
+	QueueCursor* cursor = queue_manager_get_cursor(queue_id);
+
+	cursor->head = (cursor->head + 1 + max_size) % max_size;
+	if(cursor->size > 0) {cursor->size--;};	//additional safety
+	// check if the queue head is not out of the queue's boundaries
+	if(cursor->head > max_size - 1){
+		cursor->head = 0; //if the read position reaches its max, it starts from the beginning
+	}
+
+	queue_manager_save();
+}
+
+/**
+ * @brief steps tail forward on requested cursor (used when a new item is pushed to queue)
+ * @param	queue_id	defines which queue cursor's modification is requested
+ * @param 	max_size	Tail limit. If tail reaches this boundary, we set it back to zero.
+ */
+void queue_manager_step_tail(QueueID queue_id, uint16_t max_size){
+	// inside queue manager modifications on pointers returned by queue_manager_get_cursor are allowed
+	QueueCursor* cursor = queue_manager_get_cursor(queue_id);
+
+	if(cursor->tail > max_size -1) cursor->tail = 0; //if the queue reaches its max, it overflows from the beginning
+	else cursor->tail = (cursor->tail + 1 + max_size) % max_size;
+
+	if(cursor->size > max_size-1) cursor->size = max_size;
+	else cursor->size++;
+
+	queue_manager_save();
+}
+
+void queue_manager_save(){
+	// +2 is added to the length to save the check uint32_t from flash (that validates our cursors).
+	uint16_t save_length = (CURSORS_LENGTH * sizeof(QueueCursor)) / 2 + 2;
+	uint16_t save_data[save_length];
+
+	save_data[0] = CURSOR_FLASH_VALIDITY & 0xFFFF;
+	save_data[1] = CURSOR_FLASH_VALIDITY >> 16;
+	memcpy(save_data+2, cursors, CURSORS_LENGTH * sizeof(QueueCursor));
+
+	flash_save(QUEUE_MANAGER_ADDR, 1, save_length, save_data);
+}

--- a/Core/Src/RequestQueue.c
+++ b/Core/Src/RequestQueue.c
@@ -10,10 +10,8 @@
 #define REQUEST_QUEUE_SIZE QUEUE_SIZE
 
 volatile Queue request_queue = {
+		.ID = REQUEST_QUEUE,
 		.item_size = sizeof(Request),
-		.head = 0,
-		.tail = 0,
-		.size = 0,
 		.max_size = 100,
 		.flash_page = REQ_QUEUE_ADDR,
 		.nf_pages = 1,
@@ -29,12 +27,12 @@ void request_queue_init() {
   * @return The position to insert the new request
   */
 static uint8_t find_insert_position(uint32_t time){
- 	for (int i = request_queue.head; i != request_queue.tail; i++){
+ 	for (int i = request_queue.cursor->head; i != request_queue.cursor->tail; i++){
  		if (((Request* )request_queue.data+i)->start_time > time){
  			return i;
  		}
  	}
- 	return request_queue.tail;
+ 	return request_queue.cursor->tail;
  }
 
 /**
@@ -42,15 +40,14 @@ static uint8_t find_insert_position(uint32_t time){
   * If the queue is full, the request is discarded.
   */
 void request_queue_put(Request request){
-	if (request_queue.size >= REQUEST_QUEUE_SIZE) return;
+	if (request_queue.cursor->size >= REQUEST_QUEUE_SIZE) return;
 
 	uint8_t insert_pos = find_insert_position(request.start_time);
-	for (int i = request_queue.tail; i > insert_pos; i--){
+	for (int i = request_queue.cursor->tail; i > insert_pos; i--){
 		memcpy(request_queue.data+i, request_queue.data+(i-1)*request_queue.item_size, request_queue.item_size);
 	}
 	memcpy(request_queue.data+insert_pos*request_queue.item_size, &request, request_queue.item_size);
-	request_queue.tail = (request_queue.tail+1) % REQUEST_QUEUE_SIZE;
-	request_queue.size++;
+	queue_manager_step_tail(request_queue.ID, request_queue.max_size);
 }
 
 /**
@@ -63,27 +60,6 @@ Request request_queue_get(void) {
 	Request* request = &empty_request;
 	queue_get(&request_queue, &request);
 	return *request;
-}
-
-/**
-  * Deletes a request from the request queue by its ID.
-  * If the queue is empty or the ID is not found, the function does nothing.
-  */
-/*void request_queue_delete(uint8_t id){
-	bool condition(void* item){
-		return ((Request* )item)->ID == id;
-	}
-
-	queue_delete(&request_queue, condition);
-}*/
-
-/**
-  * Clears the request queue by resetting all pointers and the size.
-  */
-void request_queue_clear(void){
-	request_queue.head = 0;
-	request_queue.tail = 0;
-	request_queue.size = 0;
 }
 
 void request_queue_save(){

--- a/Core/Src/Scheduler.c
+++ b/Core/Src/Scheduler.c
@@ -277,12 +277,3 @@ void scheduler_request_selftest(uint8_t id, uint32_t start_time, uint8_t priorit
 uint8_t scheduler_get_request_id(uint8_t idx) {
 	return (idx) ? next_request.ID : current_request.ID;
 }
-
-
-/*void scheduler_delete_request(uint8_t id) {
-	request_queue_delete(id);
-}*/
-
-void scheduler_delete_all_requests() {
-	request_queue_clear();
-}

--- a/Core/Src/Scheduler.c
+++ b/Core/Src/Scheduler.c
@@ -23,7 +23,7 @@ volatile Request current_request;
 volatile Request next_request;
 uint16_t duration;
 volatile uint8_t interrupt_counter;
-volatile uint8_t sleep_timer;
+volatile uint16_t sleep_timer;
 bool command_complete = false;
 bool restart_flag = false;
 volatile bool turnoff_check = false; // check if we need to care about current or next_request timesync

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -25,6 +25,7 @@
 #include "i2c_queue.h"
 #include "Scheduler.h"
 #include "SettingsStore.h"
+#include "QueueManager.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -101,6 +102,7 @@ int main(void)
   }
 
   HAL_GPIO_WritePin(GPIOA, GPIO_PIN_6, GPIO_PIN_SET);
+  queue_manager_init();
   settingStoreInit();
   request_queue_init();
   i2c_queue_init();

--- a/Prometheus Debug.launch
+++ b/Prometheus Debug.launch
@@ -95,6 +95,6 @@
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
-    <stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&lt;memoryBlockExpressionList context=&quot;reserved-for-future-use&quot;&gt;&lt;gdbmemoryBlockExpression address=&quot;134260736&quot; label=&quot;0x800a800&quot;/&gt;&lt;gdbmemoryBlockExpression address=&quot;536873856&quot; label=&quot;0x20000b80&quot;/&gt;&lt;gdbmemoryBlockExpression address=&quot;134266880&quot; label=&quot;0x0800C000&quot;/&gt;&lt;/memoryBlockExpressionList&gt;"/>
+    <stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&lt;memoryBlockExpressionList context=&quot;reserved-for-future-use&quot;&gt;&lt;gdbmemoryBlockExpression address=&quot;536871872&quot; label=&quot;0x200003c0&quot;/&gt;&lt;/memoryBlockExpressionList&gt;"/>
     <stringAttribute key="process_factory_id" value="com.st.stm32cube.ide.mcu.debug.launch.HardwareDebugProcessFactory"/>
 </launchConfiguration>


### PR DESCRIPTION
## What happened?
We wanted to be able to have cyclical queues, but the old flash loading algorithm wasn't capable of supporting this.
The new system saves the head, tail and size for each queues. This is the package we call QueueCursor from now on.
Also to manage cursors, I've implemented a new subsystem called QueueManager, that handles all the loading, saving of these cursors. Expect a full documentation later on!

Otherwise fixed a bug, where the sleep_timer started from 88 instead of 600, which decreased significally the idle period of our panel. The fix was to change its type from `uint8_t` to `uint16_t`.